### PR TITLE
node 12.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.10.1 as base_stage
+FROM alpine:3.10.2 as base_stage
 
 LABEL maintainer="beardedeagle <randy@heroictek.com>"
 
 # Important!  Update this no-op ENV variable when this Dockerfile
 # is updated with the current date. It will force refresh of all
 # of the base images.
-ENV REFRESHED_AT=2019-08-21 \
+ENV REFRESHED_AT=2019-08-29 \
   MIX_HOME=/usr/local/lib/elixir/.mix \
   TERM=xterm \
   LANG=C.UTF-8
@@ -27,7 +27,7 @@ RUN set -xe \
 
 FROM beardedeagle/alpine-elixir-builder:1.9.1 as elixir_stage
 
-FROM beardedeagle/alpine-node-builder:12.9.0 as node_stage
+FROM beardedeagle/alpine-node-builder:12.9.1 as node_stage
 
 FROM deps_stage as stage
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ No effort has been made to make this image suitable to run in unprivileged envir
 ## Software/Language Versions
 
 ```shell
-Alpine 3.10.1
+Alpine 3.10.2
 OTP/Erlang 22.0.7
 Elixir 1.9.1
-Rebar 3.11.1
+Rebar 3.12.0
 Hex 0.20.1
-Nodejs 12.9.0
-NPM 6.11.1
+Nodejs 12.9.1
+NPM 6.11.2
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ RUN mix deps.get --only prod \
   && MIX_ENV=prod mix release \
   && V=0.1.0; pushd _build/prod/rel; tar -czvf ${appdir}/test_app-${V}.tar.gz test_app; popd;
 
-FROM alpine:3.10.1
+FROM alpine:3.10.2
 EXPOSE 4000
 ENV appver 0.1.0
 WORKDIR /opt/test_app
@@ -76,7 +76,7 @@ RUN mix deps.get --only prod \
   && MIX_ENV=prod mix phx.digest \
   && MIX_ENV=prod mix release --env=prod
 
-FROM alpine:3.10.1
+FROM alpine:3.10.2
 EXPOSE 4000
 ENV appver 0.1.0
 WORKDIR /opt/test_app


### PR DESCRIPTION
- Bumped alpine to 3.10.2
- Bumped node to 12.9.1
- Bumpled npm to 6.11.2
- Bumped rebar to 3.12.0